### PR TITLE
Pr 66 failed workflow

### DIFF
--- a/Formula/label-studio.rb
+++ b/Formula/label-studio.rb
@@ -16,6 +16,8 @@ class LabelStudio < Formula
 
   depends_on "postgresql@14"
   depends_on "python@3.10" # Apple's Python distribution does not include pip
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
 
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"

--- a/Formula/label-studio.rb
+++ b/Formula/label-studio.rb
@@ -14,10 +14,10 @@ class LabelStudio < Formula
     sha256 ventura:       "deb442029400c58c00b8d83ba182571433fb74478ece0ab407bffddf7b51151b"
   end
 
-  depends_on "postgresql@14"
-  depends_on "python@3.10" # Apple's Python distribution does not include pip
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
+  depends_on "postgresql@14"
+  depends_on "python@3.10" # Apple's Python distribution does not include pip
 
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"


### PR DESCRIPTION
Add `pkg-config` and `rust` as build dependencies for `label-studio` to fix workflow failures.

The previous workflow failed because `cryptography` and `maturin` could not be built from source due to missing `pkg-config` and `rust` toolchains.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-26e8b95a-9a85-48c0-a9f1-174e07c8dd2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26e8b95a-9a85-48c0-a9f1-174e07c8dd2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

